### PR TITLE
fix: add types condition to fix no types problem

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     }


### PR DESCRIPTION
Now, TypeScript looks for a declaration file named `index.d.mts`, which doesn’t exist.

So, we have to add `types` condition to let it find the declaration file named `index.d.ts`.

This `types` condition should always be included **first** in the condition object.

Ref:
https://arethetypeswrong.github.io/?p=vite-plugin-oxlint%401.0.4
https://nodejs.org/api/packages.html#community-conditions-definitions
