### PR TITLE
chore: allow oxlint version 15.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-oxlint",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Oxlint plugin for vite.",
   "author": "Arnaud Riu",
   "license": "MIT",
@@ -37,7 +37,7 @@
     "vite": "^5.4.9"
   },
   "peerDependencies": {
-    "oxlint": "^0.10.2"
+    "oxlint": "^0.15.2"
   },
   "packageManager": "pnpm@9.12.1"
 }


### PR DESCRIPTION
We already use this package with oxlint 15.2 and it works, but this would remove the npm error message when installing the packages.