### PR TITLE
Update Vite and Oxlint works with Vite 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,16 +32,16 @@
     "vite-plugin"
   ],
   "dependencies": {
-    "oxlint": "^1.4.0",
+    "oxlint": "^1.11.0",
     "package-manager-detector": "^1.3.0"
   },
   "devDependencies": {
     "@types/node": "^24.0.8",
     "typescript": "^5.8.3",
-    "vite": "^7.0.0"
+    "vite": "^7.1.1"
   },
   "peerDependencies": {
-    "vite": "^6.0.7"
+    "vite": "^7.1.1"
   },
   "packageManager": "pnpm@10.12.4+sha512.5ea8b0deed94ed68691c9bad4c955492705c5eeb8a87ef86bc62c74a26b037b08ff9570f108b2e4dbd1dd1a9186fea925e527f141c648e85af45631074680184"
 }


### PR DESCRIPTION
After this, dependabot will probably add some more updates, but this PR at least makes the updates necessary to support Vite 7.